### PR TITLE
adapt to spark input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN useradd -m -u $UID -g $GID -o -s /bin/bash otg
 # Do everything that requires root user
 # install dependencies
 RUN apt-get update && \
-    apt-get install -y curl unzip wget bzip2 && \
+    apt-get install -y curl unzip wget bzip2 libgoogle-glog-dev && \
     apt-get clean
 
 # install micromamba


### PR DESCRIPTION
Install `libgoogle-glog-dev` to avoid `pyarrow` import error. Without this library, `import pyarrow as pa` resulted in the following error: `ImportError: libglog.so.0: cannot open shared object file: No such file or directory`.

This is for PR https://github.com/thehyve/otg-data-loading/pull/54